### PR TITLE
Add TextView library and QML plugin

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,2 +1,3 @@
 # Add library and QML plugin subprojects here
+add_subdirectory(TextView)
 

--- a/lib/TextView/CMakeLists.txt
+++ b/lib/TextView/CMakeLists.txt
@@ -1,0 +1,31 @@
+find_package(Qt6 REQUIRED COMPONENTS Quick Qml)
+
+qt_add_library(TextViewLib STATIC)
+
+target_sources(TextViewLib
+    PRIVATE
+        TextView.cpp
+    PUBLIC
+        TextView.h
+)
+
+target_link_libraries(TextViewLib
+    PUBLIC
+        Qt6::Quick
+)
+
+qt_add_qml_module(TextViewPlugin
+    URI UI.Editors
+    VERSION 1.0
+    CLASS_NAME UiEditorsPlugin
+    SOURCES
+        plugin.cpp
+        plugin.h
+)
+
+target_link_libraries(TextViewPlugin
+    PRIVATE
+        TextViewLib
+        Qt6::Quick
+        Qt6::Qml
+)

--- a/lib/TextView/TextView.cpp
+++ b/lib/TextView/TextView.cpp
@@ -1,0 +1,11 @@
+#include "TextView.h"
+
+TextView::TextView(QQuickItem *parent)
+    : QQuickRhiItem(parent)
+{
+}
+
+QQuickRhiItemRenderer *TextView::createRenderer()
+{
+    return nullptr;
+}

--- a/lib/TextView/TextView.h
+++ b/lib/TextView/TextView.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <QQuickRhiItem>
+#include <QtQml/qqml.h>
+
+class TextView : public QQuickRhiItem
+{
+    Q_OBJECT
+    QML_ELEMENT
+public:
+    explicit TextView(QQuickItem *parent = nullptr);
+
+protected:
+    QQuickRhiItemRenderer *createRenderer() override;
+};

--- a/lib/TextView/plugin.cpp
+++ b/lib/TextView/plugin.cpp
@@ -1,0 +1,11 @@
+#include "plugin.h"
+#include <qqml.h>
+#include "TextView.h"
+
+void UiEditorsPlugin::registerTypes(const char *uri)
+{
+    Q_ASSERT(QLatin1String(uri) == QLatin1String("UI.Editors"));
+    qmlRegisterType<TextView>(uri, 1, 0, "TextView");
+}
+
+#include "plugin.moc"

--- a/lib/TextView/plugin.h
+++ b/lib/TextView/plugin.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <QQmlExtensionPlugin>
+
+class UiEditorsPlugin : public QQmlExtensionPlugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID QQmlExtensionInterface_iid)
+
+public:
+    void registerTypes(const char *uri) override;
+};


### PR DESCRIPTION
## Summary
- add `TextView` library project
- implement `TextView` class derived from `QQuickRhiItem`
- provide `UI.Editors` QML plugin registering `TextView`
- hook new subdirectory from `lib/CMakeLists.txt`

## Testing
- `cmake ..` *(fails: Could not find Qt6)*
- `ctest --output-on-failure` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a7eafe48832daebb5d3aeae8055d