### PR TITLE
Add tests for text line and framebuffer

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,9 +9,23 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(googletest)
 
-add_executable(GLPainterTests sample_test.cpp)
+find_package(Qt6 REQUIRED COMPONENTS Core Quick)
 
-target_link_libraries(GLPainterTests PRIVATE GTest::gtest_main)
+add_executable(GLPainterTests
+    sample_test.cpp
+    text_buffer_test.cpp
+)
+
+target_link_libraries(GLPainterTests PRIVATE
+    GTest::gtest_main
+    TextViewLib
+    Qt6::Core
+    Qt6::Quick
+)
+
+target_include_directories(GLPainterTests PRIVATE
+    ${CMAKE_SOURCE_DIR}/lib/TextView
+)
 
 include(GoogleTest)
 

--- a/test/text_buffer_test.cpp
+++ b/test/text_buffer_test.cpp
@@ -1,0 +1,65 @@
+#include <gtest/gtest.h>
+#include "TextFrameBuffer.h"
+
+TEST(TextLineTest, UpdatesBounds) {
+    TextLine line;
+    TextAttributes attr;
+    TextBlock b1(5);
+    b1.elements().append({QChar('a'), attr});
+    b1.elements().append({QChar('b'), attr});
+    b1.elements().append({QChar('c'), attr});
+    line.addBlock(b1);
+
+    EXPECT_EQ(line.firstIndex(), 5);
+    EXPECT_EQ(line.lastIndex(), 7);
+
+    TextBlock b2(2);
+    b2.elements().append({QChar('x'), attr});
+    b2.elements().append({QChar('y'), attr});
+    line.addBlock(b2);
+
+    EXPECT_EQ(line.firstIndex(), 2);
+    EXPECT_EQ(line.lastIndex(), 7);
+
+    ASSERT_NE(line.elementAt(2), nullptr);
+    EXPECT_EQ(line.elementAt(2)->character, QChar('x'));
+    EXPECT_EQ(line.elementAt(3)->character, QChar('y'));
+    EXPECT_EQ(line.elementAt(5)->character, QChar('a'));
+    EXPECT_EQ(line.elementAt(7)->character, QChar('c'));
+    EXPECT_EQ(line.elementAt(4), nullptr);
+
+    line.clear();
+    EXPECT_EQ(line.firstIndex(), 0);
+    EXPECT_EQ(line.lastIndex(), -1);
+    EXPECT_TRUE(line.blocks().isEmpty());
+}
+
+TEST(TextFrameBufferTest, FillClearPutTextCollect) {
+    TextFrameBuffer fb;
+    TextAttributes attr;
+
+    fb.fill(QRect(0, 0, 3, 1), QChar('x'), attr);
+    ASSERT_EQ(fb.lines().size(), 1);
+    EXPECT_EQ(fb.lines()[0].firstIndex(), 0);
+    EXPECT_EQ(fb.lines()[0].lastIndex(), 2);
+
+    fb.clear(QRect(1, 0, 2, 1));
+    EXPECT_EQ(fb.lines()[0].firstIndex(), 0);
+    EXPECT_EQ(fb.lines()[0].lastIndex(), 0);
+    EXPECT_EQ(fb.lines()[0].elementAt(0)->character, QChar('x'));
+    EXPECT_EQ(fb.lines()[0].elementAt(1), nullptr);
+
+    fb.putText(1, 0, QStringLiteral("hello"), attr);
+    fb.writeLn(QStringLiteral("end"), attr);
+
+    auto cells = fb.collect(QRect(0, 0, 5, 3));
+    std::vector<QPoint> positions;
+    for (const auto &c : cells)
+        positions.push_back(c.position);
+
+    EXPECT_TRUE(std::find(positions.begin(), positions.end(), QPoint(0, 0)) != positions.end());
+    EXPECT_TRUE(std::find(positions.begin(), positions.end(), QPoint(0, 1)) != positions.end());
+    EXPECT_TRUE(std::find(positions.begin(), positions.end(), QPoint(4, 1)) != positions.end());
+    EXPECT_TRUE(std::find(positions.begin(), positions.end(), QPoint(0, 2)) != positions.end());
+}
+


### PR DESCRIPTION
## Summary
- add unit tests for `TextLine` and `TextFrameBuffer`
- link tests with TextViewLib and Qt modules

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6842f68f7210832d9fc285ef83be2f0b