### PR TITLE
Add FontLoader boundingRect accessor

### DIFF
--- a/lib/TextView/lib/FontLoader.cpp
+++ b/lib/TextView/lib/FontLoader.cpp
@@ -60,6 +60,11 @@ int FontLoader::glyphIndex(QChar character) const
     return m_font.glyphIndexesForString({character}).at(0);
 }
 
+QRectF FontLoader::boundingRect(int glyphIndex) const
+{
+    return m_font.boundingRect(glyphIndex);
+}
+
 QString FontLoader::familyName() const
 {
     return m_font.familyName();


### PR DESCRIPTION
## Summary
- implement `FontLoader::boundingRect` returning the glyph bounding box
- build with Qt tools installed to verify successful linkage

